### PR TITLE
Update pytest-sugar to 0.9.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ poyo==0.4.1
 py==1.4.34
 pygments==2.2.0
 pytest-cov==2.5.1
-pytest-sugar==0.8.0
+pytest-sugar==0.9.0
 pytest-timeout==1.2.0
 pytest==3.2.2
 python-dateutil==2.6.1


### PR DESCRIPTION

There's a new version of [pytest-sugar](https://pypi.python.org/pypi/pytest-sugar) available.
You are currently using **0.8.0**. I have updated it to **0.9.0**





Happy merging! 🤖

---
*Running the bot with an API key allows it to query pyup.io's API for changelogs and insecure packages. This is highly recommended for production use. [Learn More](https://pyup.io/docs/api-key/)*
