### PR TITLE
Update docker to 2.5.1

### DIFF
--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -5,7 +5,7 @@ certifi==2017.7.27.1
 chardet==3.0.4
 colorama==0.3.9
 docker-pycreds==0.2.1
-docker==2.3.0
+docker==2.5.1
 fs==2.0.11
 idna==2.6
 packaging==16.8


### PR DESCRIPTION

There's a new version of [docker](https://pypi.python.org/pypi/docker) available.
You are currently using **2.3.0**. I have updated it to **2.5.1**





Happy merging! 🤖

---
*Running the bot with an API key allows it to query pyup.io's API for changelogs and insecure packages. This is highly recommended for production use. [Learn More](https://pyup.io/docs/api-key/)*
