### PR TITLE
Update ipywidgets to 7.0.1

### DIFF
--- a/requirements-jupyter.txt
+++ b/requirements-jupyter.txt
@@ -7,7 +7,7 @@ html5lib==0.999999999
 ipykernel==4.6.1
 ipython-genutils==0.2.0
 ipython==6.2.1
-ipywidgets==6.0.1
+ipywidgets==7.0.1
 jedi==0.11.0
 jinja2==2.9.6
 jsonschema==2.6.0


### PR DESCRIPTION

There's a new version of [ipywidgets](https://pypi.python.org/pypi/ipywidgets) available.
You are currently using **6.0.1**. I have updated it to **7.0.1**





Happy merging! 🤖

---
*Running the bot with an API key allows it to query pyup.io's API for changelogs and insecure packages. This is highly recommended for production use. [Learn More](https://pyup.io/docs/api-key/)*
