### PR TITLE
Update widgetsnbextension to 3.0.3

### DIFF
--- a/requirements-jupyter.txt
+++ b/requirements-jupyter.txt
@@ -38,4 +38,4 @@ tornado==4.5.2
 traitlets==4.3.2
 wcwidth==0.1.7
 webencodings==0.5.1
-widgetsnbextension==2.0.1
+widgetsnbextension==3.0.3


### PR DESCRIPTION

There's a new version of [widgetsnbextension](https://pypi.python.org/pypi/widgetsnbextension) available.
You are currently using **2.0.1**. I have updated it to **3.0.3**





Happy merging! 🤖

---
*Running the bot with an API key allows it to query pyup.io's API for changelogs and insecure packages. This is highly recommended for production use. [Learn More](https://pyup.io/docs/api-key/)*
